### PR TITLE
Add newer PHP versions to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - nightly
 
 before_script:
   - composer update -a -o


### PR DESCRIPTION
Adding 7.3, 7.4, and nightly. In theory, there should be no other changes required.